### PR TITLE
[v1.0.18] Redesign Terminal View shortcut bar

### DIFF
--- a/CHANGELOG-JA.md
+++ b/CHANGELOG-JA.md
@@ -5,6 +5,16 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [1.0.18] - 2026-03-23
+
+### 変更
+- **Terminal Viewショートカットバーの再設計**: ボタン増加による横幅拡大を解消するためショートカットボタンを再構成
+  - デフォルト（Claude Code未起動）: `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`
+  - `↑` 押下後（updateコマンド）: `claude update`, `brew upgrade claude-code`, `←`
+  - Claude Code起動中: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`
+  - `claude update` と `brew upgrade claude-code` を `↑` ボタンでアクセスできるサブグループに移動
+  - `⇆` トグルボタンを `↑`（updateコマンドを開く）と `←`（戻る）に置換
+
 ## [1.0.17] - 2026-03-13
 
 ### 変更
@@ -1576,5 +1586,6 @@ v0.8.33以前からアップグレードする場合:
 [1.0.13]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.12...v1.0.13
 [1.0.14]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.13...v1.0.14
 [1.0.15]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.14...v1.0.15
+[1.0.18]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.17...v1.0.18
 [1.0.17]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.16...v1.0.17
 [1.0.16]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.15...v1.0.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.18] - 2026-03-23
+
+### Changed
+- **Terminal View Shortcut Bar Redesign**: Reorganized shortcut buttons to reduce bar width
+  - Default (Claude Code not running): `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`
+  - After pressing `↑` (update commands): `claude update`, `brew upgrade claude-code`, `←`
+  - Claude Code running: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`
+  - Moved `claude update` and `brew upgrade claude-code` into a separate subgroup accessible via `↑` button
+  - Replaced `⇆` toggle buttons with `↑` (open update commands) and `←` (back navigation)
+
 ## [1.0.17] - 2026-03-13
 
 ### Changed
@@ -2105,5 +2115,6 @@ If you are upgrading from v0.8.33 or earlier:
 [1.0.13]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.12...v1.0.13
 [1.0.14]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.13...v1.0.14
 [1.0.15]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.14...v1.0.15
+[1.0.18]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.17...v1.0.18
 [1.0.17]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.16...v1.0.17
 [1.0.16]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.15...v1.0.16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,26 @@ Terminal ViewでClaude Code起動中にEditor ViewからRun/Plan/Specコマン�
 - `ConfigurationProvider.ts`: フォールバック値
 - `EditorProvider.ts`: フォールバック値（4箇所）
 
+### v1.0.18変更: Terminal Viewショートカットバーの再設計
+
+ボタン増加による横幅拡大を解消するため、ショートカットバーを3グループ構成に再設計：
+
+**変更後の構成**
+```
+Claude Code未起動時（デフォルト）:
+[claude] [claude --enable-auto-mode] [claude -c] [claude -r] [↑]
+
+updateコマンド表示時（↑ 押下後）:
+[claude update] [brew upgrade claude-code] [←]
+
+Claude Code起動中:
+[/model sonnet] [/model opus] [/compact] [/clear] [←]
+```
+
+**変更箇所**
+- `resources/webview/terminal/index.html`: `shortcuts-update` グループ追加、`⇆` を `↑`/`←` に置換
+- `resources/webview/terminal/main.js`: `updateShortcutBar()` 更新、`toggleShortcuts()` を個別ハンドラに置換
+
 ### v1.0.17変更: commandPrefixデフォルト値の変更（--enable-auto-mode追加）
 
 `aiCodingSidebar.editor.commandPrefix` のデフォルト値に `--enable-auto-mode` オプションを追加：

--- a/README-JA.md
+++ b/README-JA.md
@@ -70,7 +70,7 @@ Claude Code向けに設計された、インテリジェントな自動化とコ
 | 機能 | 説明 |
 | --- | --- |
 | **Claude Code自動検知** | プロセスベースの検知（1.5秒ごとにチェック）により、プロンプト変更に影響されずClaude Codeセッションを確実に識別。Claude Codeの起動・終了時にUIとショートカットを自動切り替え |
-| **コンテキスト対応ショートカット** | 状態に応じて変化するスマートボタン：<br>- 未起動時: `claude`, `claude -c`, `claude -r`, `claude update`<br>- 起動中: `/model sonnet`, `/model opus`, `/compact`, `/clear`<br>Claude Codeセッション中に素早いモデル切り替えと共通コマンドが実行可能 |
+| **コンテキスト対応ショートカット** | 状態に応じて変化するスマートボタン：<br>- 未起動時: `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`<br>- `↑` 押下後（updateコマンド）: `claude update`, `brew upgrade claude-code`, `←`<br>- 起動中: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`<br>Claude Codeセッション中に素早いモデル切り替えとupdateコマンドが実行可能 |
 | **コマンド種別アイコン** | タブ名にコマンド種別を示すアイコンを表示：<br>▶️ Runボタン<br>📝 Planボタン<br>📑 Specボタン |
 | **動的プロセス名** | iTerm2のように、タブ名が現在実行中のプロセスを自動的に表示 |
 | **タブ-ファイル関連付け** | Editor viewからのコマンドはファイルをターミナルタブにリンク。タブ切り替え時に自動的に：<br>- 関連付けられたファイルをEditor viewで開く<br>- Plans viewをそのファイルのディレクトリに移動 |
@@ -334,14 +334,14 @@ npm run watch
 1. [GitHubのReleasesページ](https://github.com/NaokiIshimura/vscode-panel/releases)から最新のVSIXファイルをダウンロード
 2. コマンドラインからインストール:
    ```bash
-   code --install-extension ai-coding-sidebar-1.0.17.vsix
+   code --install-extension ai-coding-sidebar-1.0.18.vsix
    ```
 3. VS Codeを再起動
 
 #### ローカルビルド版を使用する場合:
 ```bash
 # releasesディレクトリから直接インストール
-code --install-extension releases/ai-coding-sidebar-1.0.17.vsix
+code --install-extension releases/ai-coding-sidebar-1.0.18.vsix
 ```
 
 #### 自分でパッケージを作成する場合:
@@ -355,7 +355,7 @@ code --install-extension releases/ai-coding-sidebar-1.0.17.vsix
    ```
 3. 生成されたVSIXファイルをインストール:
    ```bash
-   code --install-extension releases/ai-coding-sidebar-1.0.17.vsix
+   code --install-extension releases/ai-coding-sidebar-1.0.18.vsix
    ```
 4. VS Codeを再起動
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Coding Panel for Claude Code
 
-[![Version](https://img.shields.io/badge/version-1.0.15-blue.svg)](https://marketplace.visualstudio.com/items?itemName=nacn.ai-coding-sidebar) [![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-Install-blue.svg)](https://marketplace.visualstudio.com/items?itemName=nacn.ai-coding-sidebar)
+[![Version](https://img.shields.io/badge/version-1.0.18-blue.svg)](https://marketplace.visualstudio.com/items?itemName=nacn.ai-coding-sidebar) [![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-Install-blue.svg)](https://marketplace.visualstudio.com/items?itemName=nacn.ai-coding-sidebar)
 
 A powerful VS Code panel extension designed to maximize your productivity with Claude Code.
 
@@ -72,7 +72,7 @@ The embedded terminal is purpose-built for Claude Code with intelligent automati
 | Feature | Description |
 | --- | --- |
 | **Claude Code Auto-Detection** | Process-based detection (checks every 1.5s) reliably identifies Claude Code sessions independent of prompt changes. Automatically switches UI and shortcuts when Claude Code starts/exits |
-| **Context-Aware Shortcuts** | Smart buttons that change based on state:<br>- Not running: `claude`, `claude -c`, `claude -r`, `claude update`<br>- Running: `/model sonnet`, `/model opus`, `/compact`, `/clear`<br>Enables quick model switching and common commands during Claude Code sessions |
+| **Context-Aware Shortcuts** | Smart buttons that change based on state:<br>- Not running: `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`<br>- After `↑` (update commands): `claude update`, `brew upgrade claude-code`, `←`<br>- Running: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`<br>Enables quick model switching and update commands during Claude Code sessions |
 | **Command Type Icons** | Tab names display icons indicating command origin:<br>▶️ Run button<br>📝 Plan button<br>📑 Spec button |
 | **Dynamic Process Names** | Like iTerm2, tab names update automatically to show the currently running process |
 | **Tab-File Association** | Commands from Editor view link the file to the terminal tab. Switching tabs automatically:<br>- Opens the associated file in Editor view<br>- Navigates to the file's directory in Plans view |
@@ -335,14 +335,14 @@ npm run watch
 1. Download the latest VSIX file from the [GitHub Releases page](https://github.com/NaokiIshimura/vscode-panel/releases).
 2. Install via command line:
    ```bash
-   code --install-extension ai-coding-sidebar-1.0.17.vsix
+   code --install-extension ai-coding-sidebar-1.0.18.vsix
    ```
 3. Restart VS Code.
 
 #### Use a local build
 ```bash
 # Install directly from the releases directory
-code --install-extension releases/ai-coding-sidebar-1.0.17.vsix
+code --install-extension releases/ai-coding-sidebar-1.0.18.vsix
 ```
 
 #### Build the package yourself
@@ -356,7 +356,7 @@ code --install-extension releases/ai-coding-sidebar-1.0.17.vsix
    ```
 3. Install the generated VSIX file:
    ```bash
-   code --install-extension releases/ai-coding-sidebar-1.0.17.vsix
+   code --install-extension releases/ai-coding-sidebar-1.0.18.vsix
    ```
 4. Restart VS Code.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-coding-sidebar",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-coding-sidebar",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-coding-sidebar",
   "displayName": "AI Coding Panel",
   "description": "A powerful VS Code panel extension designed to maximize your productivity with Claude Code.",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "publisher": "nacn",
   "icon": "images/icon.png",
   "repository": {

--- a/resources/webview/terminal/index.html
+++ b/resources/webview/terminal/index.html
@@ -22,17 +22,22 @@
         <div class="header-row-2" id="shortcut-bar">
             <div class="shortcut-group" id="shortcuts-not-running">
                 <button class="shortcut-button" id="btn-claude">claude</button>
+                <button class="shortcut-button" id="btn-claude-enable-auto-mode">claude --enable-auto-mode</button>
                 <button class="shortcut-button" id="btn-claude-c">claude -c</button>
                 <button class="shortcut-button" id="btn-claude-r">claude -r</button>
+                <button class="shortcut-button toggle-button" id="toggle-update-shortcuts" title="Switch to update commands">↑</button>
+            </div>
+            <div class="shortcut-group hidden" id="shortcuts-update">
                 <button class="shortcut-button" id="btn-claude-update">claude update</button>
-                <button class="shortcut-button toggle-button" id="toggle-shortcuts-1" title="Switch to Claude Code commands">⇆</button>
+                <button class="shortcut-button" id="btn-brew-upgrade-claude-code">brew upgrade claude-code</button>
+                <button class="shortcut-button toggle-button" id="toggle-update-back" title="Back to shell commands">←</button>
             </div>
             <div class="shortcut-group hidden" id="shortcuts-running">
                 <button class="shortcut-button" id="btn-model-sonnet">/model sonnet</button>
                 <button class="shortcut-button" id="btn-model-opus">/model opus</button>
                 <button class="shortcut-button" id="btn-compact">/compact</button>
                 <button class="shortcut-button" id="btn-clear">/clear</button>
-                <button class="shortcut-button toggle-button" id="toggle-shortcuts-2" title="Switch to shell commands">⇆</button>
+                <button class="shortcut-button toggle-button" id="toggle-shortcuts-2" title="Switch to shell commands">←</button>
             </div>
         </div>
     </div>

--- a/resources/webview/terminal/main.js
+++ b/resources/webview/terminal/main.js
@@ -33,12 +33,15 @@
     // ショートカットバーの表示切り替え
     function updateShortcutBar(isClaudeCodeRunning) {
         const notRunning = document.getElementById('shortcuts-not-running');
+        const updateGroup = document.getElementById('shortcuts-update');
         const running = document.getElementById('shortcuts-running');
         if (isClaudeCodeRunning) {
             notRunning.classList.add('hidden');
+            updateGroup.classList.add('hidden');
             running.classList.remove('hidden');
         } else {
             notRunning.classList.remove('hidden');
+            updateGroup.classList.add('hidden');
             running.classList.add('hidden');
         }
     }
@@ -680,27 +683,35 @@
     }
 
     document.getElementById('btn-claude')?.addEventListener('click', () => sendShortcut('claude', true));
+    document.getElementById('btn-claude-enable-auto-mode')?.addEventListener('click', () => sendShortcut('claude --enable-auto-mode', true));
     document.getElementById('btn-claude-c')?.addEventListener('click', () => sendShortcut('claude -c', true));
     document.getElementById('btn-claude-r')?.addEventListener('click', () => sendShortcut('claude -r', true));
     document.getElementById('btn-claude-update')?.addEventListener('click', () => sendShortcut('claude update', false));
+    document.getElementById('btn-brew-upgrade-claude-code')?.addEventListener('click', () => sendShortcut('brew upgrade claude-code', false));
     document.getElementById('btn-model-sonnet')?.addEventListener('click', () => sendShortcut('/model sonnet', false));
     document.getElementById('btn-model-opus')?.addEventListener('click', () => sendShortcut('/model opus', false));
     document.getElementById('btn-compact')?.addEventListener('click', () => sendShortcut('/compact', false));
     document.getElementById('btn-clear')?.addEventListener('click', () => sendShortcut('/clear', false));
 
-    // トグルボタンのイベントハンドラ（ショートカット表示の切り替え）
-    function toggleShortcuts() {
+    // ↑ボタン: not-running → update グループ切り替え
+    document.getElementById('toggle-update-shortcuts')?.addEventListener('click', () => {
+        document.getElementById('shortcuts-not-running').classList.add('hidden');
+        document.getElementById('shortcuts-update').classList.remove('hidden');
+    });
+
+    // ←ボタン（updateグループ）: update → not-running グループ切り替え
+    document.getElementById('toggle-update-back')?.addEventListener('click', () => {
+        document.getElementById('shortcuts-update').classList.add('hidden');
+        document.getElementById('shortcuts-not-running').classList.remove('hidden');
+    });
+
+    // ←ボタン（runningグループ）: running → not-running グループ切り替え
+    document.getElementById('toggle-shortcuts-2')?.addEventListener('click', () => {
         if (!activeTabId) return;
-        const isClaudeRunning = claudeCodeState.get(activeTabId) || false;
-        // 状態を反転
-        const newState = !isClaudeRunning;
-        claudeCodeState.set(activeTabId, newState);
-        updateShortcutBar(newState);
-        // Extension側にも状態を通知
-        vscode.postMessage({ type: 'setClaudeCodeRunning', tabId: activeTabId, isRunning: newState });
-    }
-    document.getElementById('toggle-shortcuts-1')?.addEventListener('click', toggleShortcuts);
-    document.getElementById('toggle-shortcuts-2')?.addEventListener('click', toggleShortcuts);
+        claudeCodeState.set(activeTabId, false);
+        updateShortcutBar(false);
+        vscode.postMessage({ type: 'setClaudeCodeRunning', tabId: activeTabId, isRunning: false });
+    });
 
     // スクロールボタンのイベントハンドラ
     scrollToBottomBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Reorganized Terminal View shortcut buttons into 3 groups to reduce bar width
- Moved `claude update` and `brew upgrade claude-code` into a separate update commands subgroup

## Changes

### Changed
- **Terminal View Shortcut Bar**: Redesigned from 2 groups to 3 groups
  - Default (Claude Code not running): `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`
  - After pressing `↑` (update commands): `claude update`, `brew upgrade claude-code`, `←`
  - Claude Code running: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`
- Replaced `⇆` toggle buttons with `↑` (open update commands) and `←` (back navigation)

## Modified Files
- `resources/webview/terminal/index.html` — Added `shortcuts-update` group, replaced `⇆` with `↑`/`←`
- `resources/webview/terminal/main.js` — Updated `updateShortcutBar()`, replaced `toggleShortcuts()` with individual handlers

## Test Checklist
- [ ] npm run compile succeeds
- [ ] npm run package succeeds
- [ ] Default shortcut bar shows: `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`
- [ ] `↑` opens update commands group: `claude update`, `brew upgrade claude-code`, `←`
- [ ] `←` in update group returns to default group
- [ ] Claude Code running shows: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`
- [ ] `←` in running group returns to default group
- [ ] Claude Code auto-detection hides update group and shows running group