### PR TITLE
[v1.0.19] Replace --enable-auto-mode with --permission-mode auto

### DIFF
--- a/CHANGELOG-JA.md
+++ b/CHANGELOG-JA.md
@@ -5,6 +5,14 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [1.0.19] - 2026-07-11
+
+### 変更
+- **`--enable-auto-mode` → `--permission-mode auto`**: 廃止されたClaude CLIオプションへの参照をすべて更新
+  - `aiCodingSidebar.editor.commandPrefix` デフォルト値: `claude --enable-auto-mode` → `claude --permission-mode auto`
+  - Terminal Viewショートカットバーのボタンラベルも同様に更新
+  - `--enable-auto-mode` はClaude CLIで廃止済み。`--permission-mode auto` が後継オプション
+
 ## [1.0.18] - 2026-03-23
 
 ### 変更
@@ -1586,6 +1594,7 @@ v0.8.33以前からアップグレードする場合:
 [1.0.13]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.12...v1.0.13
 [1.0.14]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.13...v1.0.14
 [1.0.15]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.14...v1.0.15
+[1.0.19]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.18...v1.0.19
 [1.0.18]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.17...v1.0.18
 [1.0.17]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.16...v1.0.17
 [1.0.16]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.15...v1.0.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 2026-07-11
+
+### Changed
+- **`--enable-auto-mode` → `--permission-mode auto`**: Updated all references to the deprecated Claude CLI option
+  - `aiCodingSidebar.editor.commandPrefix` default value: `claude --enable-auto-mode` → `claude --permission-mode auto`
+  - Terminal View shortcut bar button label updated accordingly
+  - `--enable-auto-mode` is no longer available in the Claude CLI; `--permission-mode auto` is the replacement
+
 ## [1.0.18] - 2026-03-23
 
 ### Changed
@@ -2115,6 +2123,7 @@ If you are upgrading from v0.8.33 or earlier:
 [1.0.13]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.12...v1.0.13
 [1.0.14]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.13...v1.0.14
 [1.0.15]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.14...v1.0.15
+[1.0.19]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.18...v1.0.19
 [1.0.18]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.17...v1.0.18
 [1.0.17]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.16...v1.0.17
 [1.0.16]: https://github.com/NaokiIshimura/vscode-ai-coding-sidebar/compare/v1.0.15...v1.0.16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,21 @@ Terminal ViewでClaude Code起動中にEditor ViewからRun/Plan/Specコマン�
 - `ConfigurationProvider.ts`: フォールバック値
 - `EditorProvider.ts`: フォールバック値（4箇所）
 
+### v1.0.19変更: `--enable-auto-mode` → `--permission-mode auto` への置き換え
+
+廃止されたClaude CLIオプション `--enable-auto-mode` を `--permission-mode auto` に全面置き換え：
+
+**変更内容**
+- `aiCodingSidebar.editor.commandPrefix` デフォルト値: `claude --enable-auto-mode` → `claude --permission-mode auto`
+- Terminal Viewショートカットバーのボタンラベルを更新
+
+**変更箇所**
+- `package.json`: 設定スキーマのデフォルト値
+- `ConfigurationProvider.ts`: フォールバック値
+- `EditorProvider.ts`: フォールバック値（4箇所）
+- `resources/webview/terminal/index.html`: ボタンラベルとID
+- `resources/webview/terminal/main.js`: イベントリスナー
+
 ### v1.0.18変更: Terminal Viewショートカットバーの再設計
 
 ボタン増加による横幅拡大を解消するため、ショートカットバーを3グループ構成に再設計：
@@ -388,7 +403,7 @@ Terminal ViewでClaude Code起動中にEditor ViewからRun/Plan/Specコマン�
 **変更後の構成**
 ```
 Claude Code未起動時（デフォルト）:
-[claude] [claude --enable-auto-mode] [claude -c] [claude -r] [↑]
+[claude] [claude --permission-mode auto] [claude -c] [claude -r] [↑]
 
 updateコマンド表示時（↑ 押下後）:
 [claude update] [brew upgrade claude-code] [←]

--- a/README-JA.md
+++ b/README-JA.md
@@ -70,7 +70,7 @@ Claude Code向けに設計された、インテリジェントな自動化とコ
 | 機能 | 説明 |
 | --- | --- |
 | **Claude Code自動検知** | プロセスベースの検知（1.5秒ごとにチェック）により、プロンプト変更に影響されずClaude Codeセッションを確実に識別。Claude Codeの起動・終了時にUIとショートカットを自動切り替え |
-| **コンテキスト対応ショートカット** | 状態に応じて変化するスマートボタン：<br>- 未起動時: `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`<br>- `↑` 押下後（updateコマンド）: `claude update`, `brew upgrade claude-code`, `←`<br>- 起動中: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`<br>Claude Codeセッション中に素早いモデル切り替えとupdateコマンドが実行可能 |
+| **コンテキスト対応ショートカット** | 状態に応じて変化するスマートボタン：<br>- 未起動時: `claude`, `claude --permission-mode auto`, `claude -c`, `claude -r`, `↑`<br>- `↑` 押下後（updateコマンド）: `claude update`, `brew upgrade claude-code`, `←`<br>- 起動中: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`<br>Claude Codeセッション中に素早いモデル切り替えとupdateコマンドが実行可能 |
 | **コマンド種別アイコン** | タブ名にコマンド種別を示すアイコンを表示：<br>▶️ Runボタン<br>📝 Planボタン<br>📑 Specボタン |
 | **動的プロセス名** | iTerm2のように、タブ名が現在実行中のプロセスを自動的に表示 |
 | **タブ-ファイル関連付け** | Editor viewからのコマンドはファイルをターミナルタブにリンク。タブ切り替え時に自動的に：<br>- 関連付けられたファイルをEditor viewで開く<br>- Plans viewをそのファイルのディレクトリに移動 |
@@ -265,7 +265,7 @@ created: {{datetime}}
   "aiCodingSidebar.plans.defaultRelativePath": ".claude/plans",
   "aiCodingSidebar.plans.sortBy": "created",
   "aiCodingSidebar.plans.sortOrder": "ascending",
-  "aiCodingSidebar.editor.commandPrefix": "claude --enable-auto-mode",
+  "aiCodingSidebar.editor.commandPrefix": "claude --permission-mode auto",
   "aiCodingSidebar.editor.runCommand": "${commandPrefix} \"Review the file at ${filePath}\"",
   "aiCodingSidebar.editor.runCommandWithoutFile": "${commandPrefix} \"${editorContent}\"",
   "aiCodingSidebar.editor.planCommand": "${commandPrefix} \"Review the file at ${filePath} and create an implementation plan. Save it as a timestamped file (format: YYYY_MMDD_HHMM_SS_plan.md) in the same directory as ${filePath}.\"",

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The embedded terminal is purpose-built for Claude Code with intelligent automati
 | Feature | Description |
 | --- | --- |
 | **Claude Code Auto-Detection** | Process-based detection (checks every 1.5s) reliably identifies Claude Code sessions independent of prompt changes. Automatically switches UI and shortcuts when Claude Code starts/exits |
-| **Context-Aware Shortcuts** | Smart buttons that change based on state:<br>- Not running: `claude`, `claude --enable-auto-mode`, `claude -c`, `claude -r`, `↑`<br>- After `↑` (update commands): `claude update`, `brew upgrade claude-code`, `←`<br>- Running: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`<br>Enables quick model switching and update commands during Claude Code sessions |
+| **Context-Aware Shortcuts** | Smart buttons that change based on state:<br>- Not running: `claude`, `claude --permission-mode auto`, `claude -c`, `claude -r`, `↑`<br>- After `↑` (update commands): `claude update`, `brew upgrade claude-code`, `←`<br>- Running: `/model sonnet`, `/model opus`, `/compact`, `/clear`, `←`<br>Enables quick model switching and update commands during Claude Code sessions |
 | **Command Type Icons** | Tab names display icons indicating command origin:<br>▶️ Run button<br>📝 Plan button<br>📑 Spec button |
 | **Dynamic Process Names** | Like iTerm2, tab names update automatically to show the currently running process |
 | **Tab-File Association** | Commands from Editor view link the file to the terminal tab. Switching tabs automatically:<br>- Opens the associated file in Editor view<br>- Navigates to the file's directory in Plans view |
@@ -266,7 +266,7 @@ Add the following to `.vscode/settings.json`:
   "aiCodingSidebar.plans.defaultRelativePath": ".claude/plans",
   "aiCodingSidebar.plans.sortBy": "created",
   "aiCodingSidebar.plans.sortOrder": "ascending",
-  "aiCodingSidebar.editor.commandPrefix": "claude --enable-auto-mode",
+  "aiCodingSidebar.editor.commandPrefix": "claude --permission-mode auto",
   "aiCodingSidebar.editor.runCommand": "${commandPrefix} \"Review the file at ${filePath}\"",
   "aiCodingSidebar.editor.runCommandWithoutFile": "${commandPrefix} \"${editorContent}\"",
   "aiCodingSidebar.editor.planCommand": "${commandPrefix} \"Review the file at ${filePath} and create an implementation plan. Save it as a timestamped file (format: YYYY_MMDD_HHMM_SS_plan.md) in the same directory as ${filePath}.\"",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-coding-sidebar",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-coding-sidebar",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-coding-sidebar",
   "displayName": "AI Coding Panel",
   "description": "A powerful VS Code panel extension designed to maximize your productivity with Claude Code.",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "publisher": "nacn",
   "icon": "images/icon.png",
   "repository": {
@@ -534,7 +534,7 @@
         },
         "aiCodingSidebar.editor.commandPrefix": {
           "type": "string",
-          "default": "claude --enable-auto-mode",
+          "default": "claude --permission-mode auto",
           "description": "Command prefix used in editor commands. This is substituted for ${commandPrefix} in command templates."
         },
         "aiCodingSidebar.editor.runCommand": {

--- a/resources/webview/terminal/index.html
+++ b/resources/webview/terminal/index.html
@@ -22,7 +22,7 @@
         <div class="header-row-2" id="shortcut-bar">
             <div class="shortcut-group" id="shortcuts-not-running">
                 <button class="shortcut-button" id="btn-claude">claude</button>
-                <button class="shortcut-button" id="btn-claude-enable-auto-mode">claude --enable-auto-mode</button>
+                <button class="shortcut-button" id="btn-claude-permission-mode-auto">claude --permission-mode auto</button>
                 <button class="shortcut-button" id="btn-claude-c">claude -c</button>
                 <button class="shortcut-button" id="btn-claude-r">claude -r</button>
                 <button class="shortcut-button toggle-button" id="toggle-update-shortcuts" title="Switch to update commands">↑</button>

--- a/resources/webview/terminal/main.js
+++ b/resources/webview/terminal/main.js
@@ -683,7 +683,7 @@
     }
 
     document.getElementById('btn-claude')?.addEventListener('click', () => sendShortcut('claude', true));
-    document.getElementById('btn-claude-enable-auto-mode')?.addEventListener('click', () => sendShortcut('claude --enable-auto-mode', true));
+    document.getElementById('btn-claude-permission-mode-auto')?.addEventListener('click', () => sendShortcut('claude --permission-mode auto', true));
     document.getElementById('btn-claude-c')?.addEventListener('click', () => sendShortcut('claude -c', true));
     document.getElementById('btn-claude-r')?.addEventListener('click', () => sendShortcut('claude -r', true));
     document.getElementById('btn-claude-update')?.addEventListener('click', () => sendShortcut('claude update', false));

--- a/src/providers/EditorProvider.ts
+++ b/src/providers/EditorProvider.ts
@@ -200,7 +200,7 @@ export class EditorProvider implements vscode.WebviewViewProvider, vscode.Dispos
 
                         // Get the plan command template from settings
                         const config = vscode.workspace.getConfiguration('aiCodingSidebar');
-                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --enable-auto-mode');
+                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --permission-mode auto');
                         const commandTemplate = config.get<string>('editor.planCommand', '${commandPrefix} "Review the file at ${filePath} and create an implementation plan. Save it as a timestamped file (format: YYYY_MMDD_HHMM_SS_plan.md) in the same directory as ${filePath}."');
 
                         // Replace placeholders with safely escaped values
@@ -239,7 +239,7 @@ export class EditorProvider implements vscode.WebviewViewProvider, vscode.Dispos
 
                         // Get the spec command template from settings
                         const config = vscode.workspace.getConfiguration('aiCodingSidebar');
-                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --enable-auto-mode');
+                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --permission-mode auto');
                         const commandTemplate = config.get<string>('editor.specCommand', '${commandPrefix} "Review the file at ${filePath} and create specification documents. Save them as timestamped files (format: YYYY_MMDD_HHMM_SS_requirements.md, YYYY_MMDD_HHMM_SS_design.md, YYYY_MMDD_HHMM_SS_tasks.md) in the same directory as ${filePath}."');
 
                         // Replace placeholders with safely escaped values
@@ -288,7 +288,7 @@ export class EditorProvider implements vscode.WebviewViewProvider, vscode.Dispos
 
                         // Get the run command template from settings
                         const config = vscode.workspace.getConfiguration('aiCodingSidebar');
-                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --enable-auto-mode');
+                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --permission-mode auto');
                         const commandTemplate = config.get<string>('editor.runCommand', '${commandPrefix} "Review the file at ${filePath}"');
 
                         // Replace placeholders with safely escaped values
@@ -304,7 +304,7 @@ export class EditorProvider implements vscode.WebviewViewProvider, vscode.Dispos
                     } else if (data.editorContent && data.editorContent.trim()) {
                         // No file open - use the editor content directly
                         const config = vscode.workspace.getConfiguration('aiCodingSidebar');
-                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --enable-auto-mode');
+                        const commandPrefix = config.get<string>('editor.commandPrefix', 'claude --permission-mode auto');
                         const commandTemplate = config.get<string>('editor.runCommandWithoutFile', '${commandPrefix} "${editorContent}"');
 
                         // Replace placeholders with safely escaped values

--- a/src/services/ConfigurationProvider.ts
+++ b/src/services/ConfigurationProvider.ts
@@ -18,7 +18,7 @@ export class ConfigurationProvider {
      * コマンドプレフィックスを取得
      */
     getCommandPrefix(): string {
-        return this.getConfiguration().get<string>('editor.commandPrefix', 'claude --enable-auto-mode');
+        return this.getConfiguration().get<string>('editor.commandPrefix', 'claude --permission-mode auto');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replaced all references to the deprecated `--enable-auto-mode` Claude CLI option with `--permission-mode auto`
- `--enable-auto-mode` is no longer available in the Claude CLI; `--permission-mode auto` is the replacement

## Changes

### Changed
- **`aiCodingSidebar.editor.commandPrefix` default value**: `claude --enable-auto-mode` → `claude --permission-mode auto`
  - `package.json`: configuration schema default
  - `ConfigurationProvider.ts`: fallback value
  - `EditorProvider.ts`: fallback values (4 locations)
- **Terminal View shortcut bar button**: `claude --enable-auto-mode` → `claude --permission-mode auto`
  - `resources/webview/terminal/index.html`: button label and ID updated
  - `resources/webview/terminal/main.js`: event listener updated

## Test Checklist
- [x] `npm run compile` succeeds
- [x] `npm run package` succeeds (`releases/ai-coding-sidebar-1.0.19.vsix`)
- [ ] Extension works in debug mode
- [ ] Run/Plan/Spec buttons execute with `claude --permission-mode auto` prefix by default
- [ ] Terminal View shortcut bar shows `claude --permission-mode auto` button
- [ ] Clicking the button launches Claude Code in auto permission mode

Closes #192